### PR TITLE
Support arbitrary settings that are manually configured

### DIFF
--- a/v0.13/docker-image/v1/main.tf
+++ b/v0.13/docker-image/v1/main.tf
@@ -126,4 +126,15 @@ resource "aws_elastic_beanstalk_environment" "default" {
 			value = setting.value["value"]
 		}
 	}
+
+	// Advanced settings
+	// https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastic_beanstalk_environment#option-settings
+	dynamic "setting" {
+		for_each = var.settings
+		content {
+			name = setting.value["key"]
+			namespace = setting.value["namespace"]
+			value = setting.value["value"]
+		}
+	}
 }

--- a/v0.13/docker-image/v1/vars.tf
+++ b/v0.13/docker-image/v1/vars.tf
@@ -46,6 +46,15 @@ variable "port" {
 	description = "The exposed container port for the Docker image"
 	type = number
 }
+variable "settings" {
+	default = []
+	description = "Configuration of AWS settings for ElasticBeanstalk"
+	type = list(object({
+		key = string
+		namespace = string
+		value = string
+	}))
+}
 variable "type" {
 	default = "worker"
 	description = "The type of instance that will be running"


### PR DESCRIPTION
# Overview
Expose the underlying "settings" EB interface to clients. A common use case is to setup HTTPS support for `type = website` EB instances which can be accomplished by setting the appropriate "settings" in Terraform. 

## Support HTTPS on `type = website` EB instances
![image](https://user-images.githubusercontent.com/66394482/99557193-41664300-2977-11eb-8d54-0209d2674c8b.png)